### PR TITLE
Fix bond display, improve test coverage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BioMakie"
 uuid = "7de43156-b762-4475-b39f-ba1e1e59ee2f"
 authors = ["Daniel Kool"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 BioAlignments = "00701ae9-d1dc-5365-b64a-a3a3ebf5695e"
@@ -50,7 +50,7 @@ FastaIO = "1"
 FileIO = "1"
 GLFW = "3"
 GLMakie = "0.9, 0.10, 0.11"
-GeometryBasics = "0.4, 0.5"
+GeometryBasics = "0.4.1, 0.5"
 HTTP = "1"
 Hyperscript = "0.0.4, 0.0.5"
 ImageCore = "0.9, 0.10"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Latest release](https://img.shields.io/github/release/BioJulia/BioMakie.jl.svg)](https://github.com/BioJulia/BioMakie.jl/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/BioJulia/BioMakie.jl/blob/master/LICENSE.md)
 [![ci](https://github.com/BioJulia/BioMakie.jl/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/BioJulia/BioMakie.jl/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/BioJulia/BioMakie.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/BioJulia/BioMakie.jl)
 
 ## **Documentation:**
 

--- a/docs/src/alphashape.md
+++ b/docs/src/alphashape.md
@@ -68,10 +68,10 @@ function getspherepoints(cords::Matrix, radius::Real)
 	return [[spheres[i].data...] for i in 1:size(spheres,1)] |> combinedims |> transpose |> collect
 end
 function linesegs(arr::AbstractArray{T,3}) where T<:AbstractFloat
-    new_arr::AbstractArray{Point3f0} = []
+    new_arr::AbstractArray{Point3f} = []
     for i in 1:size(arr,1)
-        push!(new_arr, Makie.Point3f0(arr[i,1,:]))
-        push!(new_arr, Makie.Point3f0(arr[i,2,:]))
+        push!(new_arr, Makie.Point3f(arr[i,1,:]))
+        push!(new_arr, Makie.Point3f(arr[i,2,:]))
     end
     return new_arr |> combinedims |> transpose |> collect
 end
@@ -204,10 +204,10 @@ function getspherepoints(cords::Matrix, radius::Real)
 	return [[spheres[i].data...] for i in 1:size(spheres,1)] |> combinedims |> transpose |> collect
 end
 function linesegs(arr::AbstractArray{T,3}) where T<:AbstractFloat
-    new_arr::AbstractArray{Point3f0} = []
+    new_arr::AbstractArray{Point3f} = []
     for i in 1:size(arr,1)
-        push!(new_arr, Makie.Point3f0(arr[i,1,:]))
-        push!(new_arr, Makie.Point3f0(arr[i,2,:]))
+        push!(new_arr, Makie.Point3f(arr[i,1,:]))
+        push!(new_arr, Makie.Point3f(arr[i,2,:]))
     end
     return new_arr |> combinedims |> transpose |> collect
 end

--- a/src/bonds.jl
+++ b/src/bonds.jl
@@ -1114,31 +1114,31 @@ function bondshape(twoatoms::Tuple{T}; bondwidth = 0.2) where {T<:BioStructures.
     @assert length(twoatoms) == 2
 	atm1 = defaultatom(twoatoms[1])
 	atm2 = defaultatom(twoatoms[2])
-	pnt1 = GeometryBasics.Point3f0(atm1.coords)
-    pnt2 = GeometryBasics.Point3f0(atm2.coords)
+	pnt1 = GeometryBasics.Point3f(atm1.coords)
+    pnt2 = GeometryBasics.Point3f(atm2.coords)
     return GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth))
 end
 function bondshape(twoatoms::AbstractVector{T}; bondwidth = 0.2) where {T<:BioStructures.AbstractAtom}
     @assert length(twoatoms) == 2
 	atm1 = defaultatom(twoatoms[1])
 	atm2 = defaultatom(twoatoms[2])
-	pnt1 = GeometryBasics.Point3f0(atm1.coords)
-    pnt2 = GeometryBasics.Point3f0(atm2.coords)
+	pnt1 = GeometryBasics.Point3f(atm1.coords)
+    pnt2 = GeometryBasics.Point3f(atm2.coords)
     return GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth))
 end
 function bondshape(twopnts::Vector{T}; bondwidth = 0.2) where {T<:GeometryBasics.AbstractPoint}
     @assert length(twopnts) == 2
-	pnt1 = GeometryBasics.Point3f0(twopnts[1])
-    pnt2 = GeometryBasics.Point3f0(twopnts[2])
+	pnt1 = GeometryBasics.Point3f(twopnts[1])
+    pnt2 = GeometryBasics.Point3f(twopnts[2])
     return GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth))
 end
 function bondshape(twopnts::AbstractMatrix{T}; bondwidth = 0.2) where {T<:AbstractFloat}
     if size(twopnts,1) == 3 && size(twopnts,2) == 2
-		pnt1 = GeometryBasics.Point3f0(twopnts[:,1])
-    	pnt2 = GeometryBasics.Point3f0(twopnts[:,2])
+		pnt1 = GeometryBasics.Point3f(twopnts[:,1])
+    	pnt2 = GeometryBasics.Point3f(twopnts[:,2])
 	elseif size(twopnts,1) == 2 && size(twopnts,2) == 3
-		pnt1 = GeometryBasics.Point3f0(twopnts[1,:])
-    	pnt2 = GeometryBasics.Point3f0(twopnts[2,:])
+		pnt1 = GeometryBasics.Point3f(twopnts[1,:])
+    	pnt2 = GeometryBasics.Point3f(twopnts[2,:])
 	else
 		println("problem making bondshape from matrix")
 	end
@@ -1161,7 +1161,7 @@ Returns a (mesh) cylinder between two atoms or points.
 - bondwidth ------------- 0.2
 """
 function bondshapes(chn::BioStructures.Chain; algo = :knowledgebased, distance = 1.9, bondwidth = 0.2)
-    bshapes = Cylinder3{Float32}[]
+    bshapes = Cylinder{Float32}[]
 	bnds = getbonds(chn; algo = algo, cutoff = distance)
 	atms = BioStructures.collectatoms(chn)
 
@@ -1170,8 +1170,8 @@ function bondshapes(chn::BioStructures.Chain; algo = :knowledgebased, distance =
 			if bnds[i,j] == 1 && i != j
 				atm1 = defaultatom(atms[i])
 				atm2 = defaultatom(atms[j])
-				pnt1 = GeometryBasics.Point3f0(atm1.coords)
-				pnt2 = GeometryBasics.Point3f0(atm2.coords)
+				pnt1 = GeometryBasics.Point3f(atm1.coords)
+				pnt2 = GeometryBasics.Point3f(atm2.coords)
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end
@@ -1180,7 +1180,7 @@ function bondshapes(chn::BioStructures.Chain; algo = :knowledgebased, distance =
     return bshapes
 end
 function bondshapes(struc::BioStructures.MolecularStructure; algo = :knowledgebased, distance = 1.9, bondwidth = 0.2)
-	bshapes = Cylinder3{Float32}[]
+	bshapes = Cylinder{Float32}[]
 	bnds = getbonds(struc; algo = algo, cutoff = distance)
 	atms = BioStructures.collectatoms(struc)
 
@@ -1190,8 +1190,8 @@ function bondshapes(struc::BioStructures.MolecularStructure; algo = :knowledgeba
 				if bnds[k][i,j] == 1 && i != j
 					atm1 = defaultatom(atms[k][i])
 					atm2 = defaultatom(atms[k][j])
-					pnt1 = GeometryBasics.Point3f0(atm1.coords)
-					pnt2 = GeometryBasics.Point3f0(atm2.coords)
+					pnt1 = GeometryBasics.Point3f(atm1.coords)
+					pnt2 = GeometryBasics.Point3f(atm2.coords)
 					push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 				end
 			end
@@ -1201,7 +1201,7 @@ function bondshapes(struc::BioStructures.MolecularStructure; algo = :knowledgeba
     return bshapes
 end
 function bondshapes(resz::Vector{T}; algo = :knowledgebased, distance = 1.9, bondwidth = 0.2) where {T<:BioStructures.AbstractResidue}
-	bshapes = Cylinder3{Float32}[]
+	bshapes = Cylinder{Float32}[]
 	bnds = getbonds(resz; algo = algo, cutoff = distance)
 	atms = BioStructures.collectatoms(resz)
 
@@ -1210,8 +1210,8 @@ function bondshapes(resz::Vector{T}; algo = :knowledgebased, distance = 1.9, bon
 			if bnds[i,j] == 1 && i != j
 				atm1 = defaultatom(atms[i])
 				atm2 = defaultatom(atms[j])
-				pnt1 = GeometryBasics.Point3f0(atm1.coords)
-				pnt2 = GeometryBasics.Point3f0(atm2.coords)
+				pnt1 = GeometryBasics.Point3f(atm1.coords)
+				pnt2 = GeometryBasics.Point3f(atm2.coords)
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end
@@ -1220,7 +1220,7 @@ function bondshapes(resz::Vector{T}; algo = :knowledgebased, distance = 1.9, bon
     return bshapes
 end
 function bondshapes(atms::Vector{T}; algo = :knowledgebased, distance = 1.9, bondwidth = 0.2) where {T<:BioStructures.AbstractAtom}
-	bshapes = Cylinder3{Float32}[]
+	bshapes = Cylinder{Float32}[]
 	bnds = getbonds(atms; algo = algo, cutoff = distance)
 
 	for i in 1:size(bnds,1)
@@ -1228,8 +1228,8 @@ function bondshapes(atms::Vector{T}; algo = :knowledgebased, distance = 1.9, bon
 			if bnds[i,j] == 1 && i != j
 				atm1 = defaultatom(atms[i])
 				atm2 = defaultatom(atms[j])
-				pnt1 = GeometryBasics.Point3f0(atm1.coords)
-				pnt2 = GeometryBasics.Point3f0(atm2.coords)
+				pnt1 = GeometryBasics.Point3f(atm1.coords)
+				pnt2 = GeometryBasics.Point3f(atm2.coords)
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end
@@ -1238,7 +1238,7 @@ function bondshapes(atms::Vector{T}; algo = :knowledgebased, distance = 1.9, bon
     return bshapes
 end
 function bondshapes(resz::Vector{T}; algo = :covalent, distance = 1.9, bondwidth = 0.2) where {T<:MIToS.PDB.PDBResidue}
-    bshapes = Cylinder3{Float32}[]
+    bshapes = Cylinder{Float32}[]
 	bnds = getbonds(resz; algo = algo, cutoff = distance)
 	atms = [bestoccupancy(resz[i].atoms) for i in 1:length(resz)] |> flatten
 
@@ -1247,8 +1247,8 @@ function bondshapes(resz::Vector{T}; algo = :covalent, distance = 1.9, bondwidth
 			if bnds[i,j] == 1 && i != j
 				atm1 = atms[i]
 				atm2 = atms[j]
-				pnt1 = GeometryBasics.Point3f0(atm1.coordinates)
-				pnt2 = GeometryBasics.Point3f0(atm2.coordinates)
+				pnt1 = GeometryBasics.Point3f(atm1.coordinates)
+				pnt2 = GeometryBasics.Point3f(atm2.coordinates)
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end
@@ -1257,7 +1257,7 @@ function bondshapes(resz::Vector{T}; algo = :covalent, distance = 1.9, bondwidth
     return bshapes
 end
 function bondshapes(chn::BioStructures.Chain, bnds::AbstractMatrix; algo = nothing, distance = nothing, bondwidth = 0.2)
-    bshapes = Cylinder3{Float32}[]
+    bshapes = Cylinder{Float32}[]
 	atms = BioStructures.collectatoms(chn)
 
 	for i in 1:size(bnds,1)
@@ -1265,8 +1265,8 @@ function bondshapes(chn::BioStructures.Chain, bnds::AbstractMatrix; algo = nothi
 			if bnds[i,j] == 1 && i != j
 				atm1 = defaultatom(atms[i])
 				atm2 = defaultatom(atms[j])
-				pnt1 = GeometryBasics.Point3f0(atm1.coords)
-				pnt2 = GeometryBasics.Point3f0(atm2.coords)
+				pnt1 = GeometryBasics.Point3f(atm1.coords)
+				pnt2 = GeometryBasics.Point3f(atm2.coords)
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end
@@ -1275,7 +1275,7 @@ function bondshapes(chn::BioStructures.Chain, bnds::AbstractMatrix; algo = nothi
     return bshapes
 end
 function bondshapes(struc::BioStructures.MolecularStructure, bnds::AbstractMatrix; algo = nothing, cutoff = nothing, bondwidth = 0.2)
-	bshapes = Cylinder3{Float32}[]
+	bshapes = Cylinder{Float32}[]
 	atms = BioStructures.collectatoms(struc)
 
 	for k in 1:size(bnds,1)
@@ -1284,8 +1284,8 @@ function bondshapes(struc::BioStructures.MolecularStructure, bnds::AbstractMatri
 				if bnds[k][i,j] == 1 && i != j
 					atm1 = defaultatom(atms[k][i])
 					atm2 = defaultatom(atms[k][j])
-					pnt1 = GeometryBasics.Point3f0(atm1.coords)
-					pnt2 = GeometryBasics.Point3f0(atm2.coords)
+					pnt1 = GeometryBasics.Point3f(atm1.coords)
+					pnt2 = GeometryBasics.Point3f(atm2.coords)
 					push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 				end
 			end
@@ -1295,7 +1295,7 @@ function bondshapes(struc::BioStructures.MolecularStructure, bnds::AbstractMatri
     return bshapes
 end
 function bondshapes(resz::Vector{T}, bnds::AbstractMatrix; bondwidth = 0.2) where {T<:BioStructures.AbstractResidue}
-	bshapes = Cylinder3{Float32}[]
+	bshapes = Cylinder{Float32}[]
 	atms = BioStructures.collectatoms(resz)
 
 	for i in 1:size(bnds,1)
@@ -1303,8 +1303,8 @@ function bondshapes(resz::Vector{T}, bnds::AbstractMatrix; bondwidth = 0.2) wher
 			if bnds[i,j] == 1 && i != j
 				atm1 = defaultatom(atms[i])
 				atm2 = defaultatom(atms[j])
-				pnt1 = GeometryBasics.Point3f0(atm1.coords)
-				pnt2 = GeometryBasics.Point3f0(atm2.coords)
+				pnt1 = GeometryBasics.Point3f(atm1.coords)
+				pnt2 = GeometryBasics.Point3f(atm2.coords)
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end
@@ -1313,7 +1313,7 @@ function bondshapes(resz::Vector{T}, bnds::AbstractMatrix; bondwidth = 0.2) wher
     return bshapes
 end
 function bondshapes(resz::Vector{T}, bnds::AbstractMatrix; bondwidth = 0.2) where {T<:MIToS.PDB.PDBResidue}
-    bshapes = Cylinder3{Float32}[]
+    bshapes = Cylinder{Float32}[]
 	atms = [bestoccupancy(resz[i].atoms) for i in 1:length(resz)] |> flatten
 
 	for i in 1:size(bnds,1)
@@ -1321,8 +1321,8 @@ function bondshapes(resz::Vector{T}, bnds::AbstractMatrix; bondwidth = 0.2) wher
 			if bnds[i,j] == 1 && i != j
 				atm1 = atms[i]
 				atm2 = atms[j]
-				pnt1 = GeometryBasics.Point3f0(atm1.coordinates)
-				pnt2 = GeometryBasics.Point3f0(atm2.coordinates)
+				pnt1 = GeometryBasics.Point3f(atm1.coordinates)
+				pnt2 = GeometryBasics.Point3f(atm2.coordinates)
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end
@@ -1331,15 +1331,15 @@ function bondshapes(resz::Vector{T}, bnds::AbstractMatrix; bondwidth = 0.2) wher
     return bshapes
 end
 function bondshapes(atms::Vector{T}, bnds::AbstractMatrix; bondwidth = 0.2) where {T<:BioStructures.AbstractAtom}
-	bshapes = Cylinder3{Float32}[]
+	bshapes = Cylinder{Float32}[]
 
 	for i in 1:size(bnds,1)
 		for j in (i+1):size(bnds,1)
 			if bnds[i,j] == 1 && i != j
 				atm1 = defaultatom(atms[i])
 				atm2 = defaultatom(atms[j])
-				pnt1 = GeometryBasics.Point3f0(atm1.coords)
-				pnt2 = GeometryBasics.Point3f0(atm2.coords)
+				pnt1 = GeometryBasics.Point3f(atm1.coords)
+				pnt2 = GeometryBasics.Point3f(atm2.coords)
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end
@@ -1348,15 +1348,15 @@ function bondshapes(atms::Vector{T}, bnds::AbstractMatrix; bondwidth = 0.2) wher
     return bshapes
 end
 function bondshapes(atms::Vector{T}, bnds::AbstractMatrix; bondwidth = 0.2) where {T<:MIToS.PDB.PDBAtom}
-    bshapes = Cylinder3{Float32}[]
+    bshapes = Cylinder{Float32}[]
 
 	for i in 1:size(bnds,1)
 		for j in (i+1):size(bnds,1)
 			if bnds[i,j] == 1 && i != j
 				atm1 = atms[i]
 				atm2 = atms[j]
-				pnt1 = GeometryBasics.Point3f0(atm1.coordinates)
-				pnt2 = GeometryBasics.Point3f0(atm2.coordinates)
+				pnt1 = GeometryBasics.Point3f(atm1.coordinates)
+				pnt2 = GeometryBasics.Point3f(atm2.coordinates)
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end
@@ -1366,14 +1366,14 @@ function bondshapes(atms::Vector{T}, bnds::AbstractMatrix; bondwidth = 0.2) wher
 end
 function bondshapes(cords::AbstractArray{T}; algo = :covalent, distance = 1.9, bondwidth = 0.2) where {T<:AbstractFloat}
 	@assert size(cords,2) == 3 "coords must be an N x 3 matrix"
-    bshapes = Cylinder3{Float32}[]
+    bshapes = Cylinder{Float32}[]
 	bnds = getbonds(cords; algo = algo, cutoff = distance)
 
 	for i in 1:size(bnds,1)
 		for j in (i+1):size(bnds,1)
 			if bnds[i,j] == 1 && i != j
-				pnt1 = GeometryBasics.Point3f0(cords[i,:])
-				pnt2 = GeometryBasics.Point3f0(cords[j,:])
+				pnt1 = GeometryBasics.Point3f(cords[i,:])
+				pnt2 = GeometryBasics.Point3f(cords[j,:])
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end
@@ -1383,13 +1383,13 @@ function bondshapes(cords::AbstractArray{T}; algo = :covalent, distance = 1.9, b
 end
 function bondshapes(cords::AbstractArray{T}, bnds::AbstractMatrix; bondwidth = 0.2) where {T<:AbstractFloat}
 	@assert size(cords,2) == 3 "coords must be an N x 3 matrix"
-    bshapes = Cylinder3{Float32}[]
+    bshapes = Cylinder{Float32}[]
 
 	for i in 1:size(bnds,1)
 		for j in (i+1):size(bnds,1)
 			if bnds[i,j] == 1 && i != j
-				pnt1 = GeometryBasics.Point3f0(cords[i,:])
-				pnt2 = GeometryBasics.Point3f0(cords[j,:])
+				pnt1 = GeometryBasics.Point3f(cords[i,:])
+				pnt2 = GeometryBasics.Point3f(cords[j,:])
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end
@@ -1399,14 +1399,14 @@ function bondshapes(cords::AbstractArray{T}, bnds::AbstractMatrix; bondwidth = 0
 end
 function bondshapes(cords::AbstractArray{T}, noth::Nothing; algo = :covalent, distance = 1.9, bondwidth = 0.2) where {T<:AbstractFloat}
 	@assert size(cords,2) == 3 "coords must be an N x 3 matrix"
-    bshapes = Cylinder3{Float32}[]
+    bshapes = Cylinder{Float32}[]
 	bnds = getbonds(cords; algo = algo, cutoff = distance)
 
 	for i in 1:size(bnds,1)
 		for j in (i+1):size(bnds,1)
 			if bnds[i,j] == 1 && i != j
-				pnt1 = GeometryBasics.Point3f0(cords[i,:])
-				pnt2 = GeometryBasics.Point3f0(cords[j,:])
+				pnt1 = GeometryBasics.Point3f(cords[i,:])
+				pnt2 = GeometryBasics.Point3f(cords[j,:])
 				push!(bshapes, GeometryBasics.Cylinder(pnt1,pnt2,Float32(bondwidth)))
 			end
 		end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,10 +1,10 @@
 export protsmiles,
     elecolors,
-    cpkcolors, 
-    aquacolors, 
-    shapelycolors, 
-    leskcolors, 
-    maecolors, 
+    cpkcolors,
+    aquacolors,
+    shapelycolors,
+    leskcolors,
+    maecolors,
     cinemacolors,
     getbiocolors,
     getprotosyn
@@ -85,7 +85,7 @@ cpkcolors = OrderedDict("C" => RGB(200.0,200.0,200.0),
                         "NA" => RGB(0.0,0.0,255.0),
                         "FE" => RGB(255.0,165.0,0.0),
                         "CA" => RGB(128.0,128.0,144.0),
-                        "X" => RGB(255.0,20.0,147.0)			  
+                        "X" => RGB(255.0,20.0,147.0)
 )
 aquacolors = OrderedDict(   "C" => RGB(0.5,0.5,0.5),
                             "N" => RGB(0.472,0.211,0.499),
@@ -197,12 +197,12 @@ cinemacolors = OrderedDict(
     "X" => :gray
 )
 function getbiocolors()
-    return OrderedDict( :elecolors => elecolors, 
-                        :cpkcolors => cpkcolors, 
-                        :aquacolors => aquacolors, 
-                        :shapelycolors => shapelycolors, 
-                        :leskcolors => leskcolors, 
-                        :maecolors => maecolors, 
+    return OrderedDict( :elecolors => elecolors,
+                        :cpkcolors => cpkcolors,
+                        :aquacolors => aquacolors,
+                        :shapelycolors => shapelycolors,
+                        :leskcolors => leskcolors,
+                        :maecolors => maecolors,
                         :cinemacolors => cinemacolors)
 end
 SMILESaa = OrderedDict(
@@ -344,10 +344,10 @@ function surfacearea(coordinates, connectivity)
     return totalarea
 end
 function linesegs(arr::AbstractArray{T,3}) where T<:AbstractFloat
-    new_arr::AbstractArray{Point3f0} = []
+    new_arr::AbstractArray{Point3f} = []
     for i in 1:size(arr,1)
-        push!(new_arr, Makie.Point3f0(arr[i,1,:]))
-        push!(new_arr, Makie.Point3f0(arr[i,2,:]))
+        push!(new_arr, Makie.Point3f(arr[i,1,:]))
+        push!(new_arr, Makie.Point3f(arr[i,2,:]))
     end
     return new_arr |> combinedims |> transpose |> collect
 end
@@ -416,8 +416,8 @@ resletterdict = OrderedDict(
 	"J" => "XLE"
 )
 # Dictionary for Kidera physical property factors, from:
-# Kenta Nakai, Akinori Kidera, Minoru Kanehisa, Cluster analysis of amino acid indices for prediction of protein structure and function, 
-# Protein Engineering, Design and Selection, Volume 2, Issue 2, July 1988, Pages 93–100, https://doi.org/10.1093/protein/2.2.93 
+# Kenta Nakai, Akinori Kidera, Minoru Kanehisa, Cluster analysis of amino acid indices for prediction of protein structure and function,
+# Protein Engineering, Design and Selection, Volume 2, Issue 2, July 1988, Pages 93–100, https://doi.org/10.1093/protein/2.2.93
 kideradict = OrderedDict(
     "A" => [-1.56,-1.67,-0.97,-0.27,-0.93,-0.78,-0.2,-0.08,0.21,-0.48],
     "R" => [0.22,1.27,1.37,1.87,-1.7,0.46,0.92,-0.39,0.23,0.93],
@@ -470,7 +470,7 @@ kideradict = OrderedDict(
     "ASX" => [0.86,-0.145,-0.85,0.81,-0.37,0.26,-0.805,0.85,0.93,-0.515],
     "GLX" => [-0.96,0.215,-0.77,1.135,-0.105,0.495,0.44,-0.165,-0.19,-1.225],
     "XAA" => [0,0,0,0,0,0,0,0,0,0],
-    "XLE" => [-0.885,-0.08,0.775,-0.935,-0.545,-1.01,0.065,-0.125,0.555,-0.425] 
+    "XLE" => [-0.885,-0.08,0.775,-0.935,-0.545,-1.01,0.065,-0.125,0.555,-0.425]
 )
 function kdict(str::AbstractString)
     if length(str) == 3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -168,8 +168,11 @@ firstvalue(dict::AbstractDict) = first(values(dict))
     @test atmcolors[][end] == RGB{Float64}(0.65,0.96,0.7)
 
     # High-level plot (BioStructures)
-    fig = plotstruc(only(chn))
-    display(fig)
+    for plottype in (:ballandstick, :covalent, :spacefilling),
+        bondtype in (:knowledgebased, :covalent, :distance)
+        fig = plotstruc(only(chn); plottype, bondtype)
+        display(fig)
+    end
 
     # MIToS
     struc = MIToS.PDB.read_file("$(dir)/2VB1.pdb", MIToS.PDB.PDBFile);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,6 +167,10 @@ firstvalue(dict::AbstractDict) = first(values(dict))
     @test atmcolors[][5] == RGB{Float64}(0.5,0.5,0.5)
     @test atmcolors[][end] == RGB{Float64}(0.65,0.96,0.7)
 
+    # High-level plot (BioStructures)
+    fig = plotstruc(only(chn))
+    display(fig)
+
     # MIToS
     struc = MIToS.PDB.read_file("$(dir)/2VB1.pdb", MIToS.PDB.PDBFile);
     chn = MIToS.PDB.select_residues(struc, model="1", chain="A", group="ATOM")


### PR DESCRIPTION
Display of bonds was using names that haven't been valid since
GeometryBasics got released. However, the change from `Point3f0` to
`Point3f` occurred in a patch release, 0.4.1:

https://github.com/JuliaGeometry/GeometryBasics.jl/commit/17fe9e8db8caa30d1cd760843b283fce4848d922

Thus we should make this the minimum required version of GeometryBasics.

Unfortunately, these name changes weren't caught by the tests, as the
test coverage is low (3% according to Codecov). This adds a test of
`plotstruc` directly, which would have caught these issues and should
substantially improve the test coverage.