### PR TITLE
[compat] julia 1.10+, test on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.10'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -66,7 +66,7 @@ PairwiseListMatrices = "0.11"
 SplitApplyCombine = "1.2"
 TableTraitsUtils = "1"
 TensorCast = "0.4.8"
-julia = "1"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Formerly this package declared compatibility with any Julia 1.x.y, but
only ran tests on "1" (meaning the current release). Of course, it would
be surprising if this package still worked in its current form on Julia
1.0.0. However, since we don't run tests for anything but the current
version of Julia, we have no way of knowing what it takes for it to
work, and consequently no way of ensuring that users with working
systems won't get an upgrade that breaks BioMakie for them.

Fortunately, the current LTS, Julia 1.10, is quite recent and I can
verify that the package works on that version. To put matters on sound
footing for future development, this PR adopts 1.10 as the minimum
version, and adds a test for Julia 1.10 to the CI workflow.